### PR TITLE
Corrects LibraryFileBlockController call

### DIFF
--- a/packages/flickr/CHANGELOG
+++ b/packages/flickr/CHANGELOG
@@ -1,3 +1,4 @@
+1.2.1 - Small fix for concrete5.6
 1.2 - updated for concrete5.5
 1.1 - Moved to package format, converted PHP short tags.
 1.0 - Initial release.

--- a/packages/flickr/blocks/flickr/controller.php
+++ b/packages/flickr/blocks/flickr/controller.php
@@ -85,7 +85,7 @@ class FlickrBlockController extends BlockController {
 			$resizedFileCacheName='flickr_cached_img_'.$photo_key.'_'.$this->maxWidth.'x'.$this->maxHeight.$file_ext;
 			$fileCachePathRel=REL_DIR_FILES_CACHE.'/'.$resizedFileCacheName;		
 			if( !file_exists(DIR_FILES_CACHE.'/'.$resizedFileCacheName) ){
-				echo LibraryFileBlockController::createImage(DIR_FILES_CACHE.'/'.$fileCacheName,DIR_FILES_CACHE.'/'.$resizedFileCacheName,intval($this->maxWidth),intval($this->maxHeight));
+				echo Loader::helper('image')->create(DIR_FILES_CACHE.'/'.$fileCacheName,DIR_FILES_CACHE.'/'.$resizedFileCacheName,intval($this->maxWidth),intval($this->maxHeight));
 			}
 		}
 		return $fileCachePathRel;
@@ -104,5 +104,3 @@ class FlickrBlockController extends BlockController {
 		fclose($tmpFile);
 	}
 }
-
-?>

--- a/packages/flickr/controller.php
+++ b/packages/flickr/controller.php
@@ -6,7 +6,7 @@ class FlickrPackage extends Package {
 
 	protected $pkgHandle = 'flickr';
 	protected $appVersionRequired = '5.5';
-	protected $pkgVersion = '1.2';
+	protected $pkgVersion = '1.2.1-dev';
 	
 	public function getPackageDescription() {
 		return t("Display photos from the website Flickr.com");
@@ -23,8 +23,4 @@ class FlickrPackage extends Package {
 		BlockType::installBlockTypeFromPackage('flickr', $pkg);
 		
 	}
-
-
-
-
 }


### PR DESCRIPTION
Replaces LibraryFileBlockController::create() calle with
ImageHelper::create() call as LibraryFileBlockController::create() no
longer exists. This change is backwards compatible with earlier
versions.
